### PR TITLE
Feature/Remove redundant migration settings

### DIFF
--- a/Sources/CoreDataHero/CoreData/CoreDataOperator.swift
+++ b/Sources/CoreDataHero/CoreData/CoreDataOperator.swift
@@ -81,11 +81,6 @@ public class CoreDataOperator {
         let storeType: NSPersistentContainer.StoreType = databaseURL != nil ? .sqlite : .memory
         description.type = storeType.rawValue
         
-        // Set the following options to enable Automatic Lightweight Migration.
-        // https://developer.apple.com/documentation/coredata/using_lightweight_migration
-        description.setOption(NSNumber(true), forKey: NSMigratePersistentStoresAutomaticallyOption)
-        description.setOption(NSNumber(true), forKey: NSInferMappingModelAutomaticallyOption)
-        
         container.persistentStoreDescriptions = [description]
         
         container.loadPersistentStores { description, error in


### PR DESCRIPTION
**Description**
Removes the two lines to set automatic migration and inferred mapping model settings to `true` since we're using a `NSPersistentStoreDescription`, which defaults both of these options to `true`.

https://developer.apple.com/documentation/coredata/nspersistentstoredescription/1640566-shouldmigratestoreautomatically
> If this is set to false and the store is out of sync, attempting to load the store produces an error. If this is set to true and the store is out of sync, attempting to load the store causes Core Data to attempt a migration. This flag is set to true by default.

https://developer.apple.com/documentation/coredata/nspersistentstoredescription/1640623-shouldinfermappingmodelautomatic
> If this flag is set to true and the value of the shouldMigrateStoreAutomatically is true, the coordinator attempts to infer a mapping model if none can be found. The default for this flag is true.