### PR TITLE
Feature/Update entity name resolution

### DIFF
--- a/Sources/CoreDataHero/CoreData/CoreDataOperator.swift
+++ b/Sources/CoreDataHero/CoreData/CoreDataOperator.swift
@@ -150,7 +150,7 @@ public class CoreDataOperator {
         }
         
         // Instead of using T.fetchRequest(), we build the FetchRequest so we don't need to cast the result
-        let fetchRequest = NSFetchRequest<T>(entityName: String(describing: T.self))
+        let fetchRequest = NSFetchRequest<T>(entityName: String(describing: type.self))
         fetchRequest.includesPropertyValues = false
         fetchRequest.includesSubentities = false
         fetchRequest.predicate = predicate
@@ -171,7 +171,7 @@ public class CoreDataOperator {
             throw UBCoreDataError.managedObjectContextNotFound
         }
         
-        return NSEntityDescription.insertNewObject(forEntityName: String(describing: T.self), into: context) as? T
+        return NSEntityDescription.insertNewObject(forEntityName: String(describing: type.self), into: context) as? T
     }
     
     // MARK: Delete
@@ -210,14 +210,14 @@ public class CoreDataOperator {
         let useBatchRequest = canBatchDelete && batchDelete
         
         if useBatchRequest {
-            let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: String(describing: T.self))
+            let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: String(describing: type.self))
             fetchRequest.includesPropertyValues = false
             fetchRequest.predicate = predicate
             let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
             
             try context.executeAndMergeChanges(using: deleteRequest)
         } else {
-            let fetchRequest = NSFetchRequest<T>(entityName: String(describing: T.self))
+            let fetchRequest = NSFetchRequest<T>(entityName: String(describing: type.self))
             fetchRequest.includesPropertyValues = false
             fetchRequest.predicate = predicate
             
@@ -263,7 +263,7 @@ public class CoreDataOperator {
         }
         
         // Instead of using T.fetchRequest(), we build the FetchRequest so we don't need to cast the result
-        let fetchRequest = NSFetchRequest<T>(entityName: String(describing: T.self))
+        let fetchRequest = NSFetchRequest<T>(entityName: String(describing: type.self))
         fetchRequest.predicate = predicate
         fetchRequest.fetchLimit = 1
         
@@ -290,7 +290,7 @@ public class CoreDataOperator {
         }
         
         // Instead of using T.fetchRequest(), we build the FetchRequest so we don't need to cast the result
-        let fetchRequest = NSFetchRequest<T>(entityName: String(describing: T.self))
+        let fetchRequest = NSFetchRequest<T>(entityName: String(describing: type.self))
         fetchRequest.predicate = predicate
         fetchRequest.sortDescriptors = sortDescriptors
         


### PR DESCRIPTION
**Description**
Previously we used `String(describing: T.self)` to resolve an entity name. However, if you were to set up a heterogenous collection of `NSManagedObject`s and funnel each of those through these `CoreDataOperator` methods, the generic system would end up resolving `String(describing: T.self)` to just `NSManagedObject` instead of the concrete type.

Example:
```swift
typealias DeletionInfo = (type: NSManagedObject.Type, predicate: NSPredicate)
let typesToDelete: [DeletionInfo] = [
DeletionInfo(Cat.self, myCatPredicate),
DeletionInfo(Dog.self, myDogPredicate),
]

for item in itemsToDelete {
    CoreDataOperator.shared.deleteAll(of: item.type, with: item.predicate) // Error resolving entity name
}
```

By using the concrete, passed in type (`String(describing: type.self)`) the system correctly resolves the entity name.
