### PR TITLE
Feature/Avoid deleting stored files when URL path is empty

### DIFF
--- a/Sources/CoreDataHero/Extensions/NSPersistentStore+DeleteStoreFiles.swift
+++ b/Sources/CoreDataHero/Extensions/NSPersistentStore+DeleteStoreFiles.swift
@@ -5,15 +5,28 @@ import CoreData
 extension NSPersistentStore {
     /// Deletes the store's .sqlite, .sqlite-shm, and .sqlite-wal files.
     func deleteStoreFiles() throws {
-        guard let storeURLPath = self.url?.path, !storeURLPath.isEmpty else {
+        guard let storeURLPath = self.url?.path else {
             return
         }
         
-        // Remove the .sqlite file.
-        try FileManager.default.removeItem(atPath: storeURLPath)
-        // Remove the shared memory (.sqlite-shm) file.
-        try FileManager.default.removeItem(atPath: storeURLPath.appending("-shm"))
-        // Remove the write ahead logging (.sqlite-wal) file.
-        try FileManager.default.removeItem(atPath: storeURLPath.appending("-wal"))
+        let filePaths = [
+            storeURLPath, // The .sqlite file
+            storeURLPath.appending("-shm"), // The shared memory (.sqlite-shm) file
+            storeURLPath.appending("-wal"), // The write ahead logging (.sqlite-wal) file
+        ]
+        
+        for filePath in filePaths {
+            try FileManager.default.deleteFileIfFileExists(atPath: filePath)
+        }
+    }
+}
+
+// MARK: - FileManager + Utilities
+
+private extension FileManager {
+    func deleteFileIfFileExists(atPath path: String) throws {
+        if self.fileExists(atPath: path) {
+            try self.removeItem(atPath: path)
+        }
     }
 }

--- a/Sources/CoreDataHero/Extensions/NSPersistentStore+DeleteStoreFiles.swift
+++ b/Sources/CoreDataHero/Extensions/NSPersistentStore+DeleteStoreFiles.swift
@@ -5,7 +5,7 @@ import CoreData
 extension NSPersistentStore {
     /// Deletes the store's .sqlite, .sqlite-shm, and .sqlite-wal files.
     func deleteStoreFiles() throws {
-        guard let storeURLPath = self.url?.path else {
+        guard let storeURLPath = self.url?.path, !storeURLPath.isEmpty else {
             return
         }
         


### PR DESCRIPTION
**Description**
Ensures the `storeURLPath` is not an empty string before attempting to delete items, which avoid unnecessary thrown errors.
